### PR TITLE
feat: add AppStream stock icon and packaging tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,15 @@ to index all new packages into database
 
 
 ![Results](result.png?raw=true)
+
+
+AppStream
+---------
+
+The package ships AppStream metadata (`io.github.vitexsoftware.debs2sql.metainfo.xml`)
+and a scalable stock icon (`debs2sql`) installed to the hicolor icon theme:
+
+```
+/usr/share/icons/hicolor/scalable/apps/debs2sql.svg
+/usr/share/metainfo/io.github.vitexsoftware.debs2sql.metainfo.xml
+```

--- a/debian/Jenkinsfile
+++ b/debian/Jenkinsfile
@@ -1,8 +1,15 @@
 #!groovy
 
-// Current version of this Pipeline https://github.com/VitexSoftware/BuildImages/blob/main/Test/Jenkinsfile-parael
+// Current version of this Pipeline https://github.com/VitexSoftware/BuildImages/blob/main/Test/Jenkinsfile
 
-String[] distributions = ['debian:bookworm', 'debian:trixie', 'debian:forky', 'ubuntu:jammy', 'ubuntu:noble']
+String[] distributions = [
+			'debian:bookworm', 
+			'debian:trixie', 
+			'debian:forky', 
+			'ubuntu:jammy', 
+			'ubuntu:noble',
+			'ubuntu:resolute',
+]
 
 String vendor = 'vitexsoftware'
 //String distroFamily = ''
@@ -19,6 +26,7 @@ properties([
 node() {
     ansiColor('xterm') {
         stage('SCM Checkout') {
+            sh 'sudo chown -R jenkins:jenkins . 2>/dev/null || true'
             checkout scm
         }
     }
@@ -40,6 +48,7 @@ distributions.each { distro ->
         node {
             ansiColor('xterm') {
                 stage('Checkout ' + distroName) {
+                    sh 'sudo chown -R jenkins:jenkins . 2>/dev/null || true'
                     checkout scm
                     def imageName = vendor + '/' + distro
                     buildImage = docker.image(imageName)
@@ -52,10 +61,22 @@ distributions.each { distro ->
                 }
                 stage('Build ' + distroName) {
                     buildImage.inside {
+                        // Set unique build directories for this parallel build to avoid conflicts
+                        def uniqueBuildId = env.BUILD_NUMBER + '-' + distroCode + '-' + env.EXECUTOR_NUMBER
+                        sh '''
+                            export DH_INTERNAL_BUILDDIR="/tmp/debhelper-build-''' + uniqueBuildId + '''"
+                            export TMPDIR="/tmp/build-''' + uniqueBuildId + '''"
+                            mkdir -p "$DH_INTERNAL_BUILDDIR" "$TMPDIR"
+                        '''
                         sh 'dch -b -v ' + buildVer  + ' "' + env.BUILD_TAG  + '"'
                         sh 'sudo apt-get update --allow-releaseinfo-change'
                         sh 'sudo chown jenkins:jenkins ..'
-                        sh 'debuild-pbuilder -r"sudo -E" -i -us -uc -b'
+                        sh 'sudo rm -rf debian/$(dpkg-parsechangelog --show-field Source)/ debian/.debhelper/ debian/tmp/'
+                        sh '''
+                            export DH_INTERNAL_BUILDDIR="/tmp/debhelper-build-''' + uniqueBuildId + '''"
+                            export TMPDIR="/tmp/build-''' + uniqueBuildId + '''"
+                            debuild-pbuilder -r"sudo -E" -i -us -uc -b
+                        '''
                         sh 'mkdir -p $WORKSPACE/dist/debian/ ; rm -rf $WORKSPACE/dist/debian/* ; for deb in $(cat debian/files | awk \'{print $1}\'); do mv "../$deb" $WORKSPACE/dist/debian/; done'
                         artifacts = sh (
                             script: "cat debian/files | awk '{print \$1}'",
@@ -77,19 +98,32 @@ distributions.each { distro ->
                         ]
 
                     def sorted_artifacts = artifacts.toList()
-                    installOrder.each { pkgPrefix ->
-                        def debFile = null
-                        for (item in sorted_artifacts) {
-                            def itemStr = item.toString()
-                            if (itemStr.startsWith(pkgPrefix) && itemStr.endsWith('.deb')) {
-                                debFile = itemStr
-                                break
+                    
+                    // If installOrder is empty, install all produced packages
+                    if (installOrder.isEmpty()) {
+                        sorted_artifacts.each { deb_file ->
+                            if (deb_file.endsWith('.deb')) {
+                                def pkgName = deb_file.tokenize('/')[-1].replaceFirst(/_.*/, '')
+                                sh 'echo -e "${GREEN} installing ' + pkgName + ' on `lsb_release -sc` ${ENDCOLOR} "'
+                                sh 'sudo DEBIAN_FRONTEND=noninteractive DEBCONF_DEBUG=' + debconf_debug + ' apt-get -y install ' + pkgName
                             }
                         }
-                        if (debFile) {
-                            def pkgName = debFile.tokenize('/')[-1].replaceFirst(/_.*/, '')
-                            sh 'echo -e "${GREEN} installing ' + pkgName + ' on `lsb_release -sc` ${ENDCOLOR} "'
-                            sh 'sudo DEBIAN_FRONTEND=noninteractive DEBCONF_DEBUG=' + debconf_debug + ' apt-get -y install ' + pkgName + ' || sudo apt-get -y -f install'
+                    } else {
+                        // Install packages in specified order
+                        installOrder.each { pkgPrefix ->
+                            def debFile = null
+                            for (item in sorted_artifacts) {
+                                def itemStr = item.toString()
+                                if (itemStr.startsWith(pkgPrefix) && itemStr.endsWith('.deb')) {
+                                    debFile = itemStr
+                                    break
+                                }
+                            }
+                            if (debFile) {
+                                def pkgName = debFile.tokenize('/')[-1].replaceFirst(/_.*/, '')
+                                sh 'echo -e "${GREEN} installing ' + pkgName + ' on `lsb_release -sc` ${ENDCOLOR} "'
+                                sh 'sudo DEBIAN_FRONTEND=noninteractive DEBCONF_DEBUG=' + debconf_debug + ' apt-get -y install ' + pkgName
+                            }
                         }
                     }
 
@@ -105,6 +139,7 @@ distributions.each { distro ->
 
                         // Cleanup: remove any produced files named in debian/files
                         // Try both the dist location and any potential original locations referenced by debian/files
+                        def uniqueBuildId = env.BUILD_NUMBER + '-' + distroCode + '-' + env.EXECUTOR_NUMBER
                         sh '''
                             set -e
                             if [ -f debian/files ]; then
@@ -115,6 +150,9 @@ distributions.each { distro ->
                                 rm -f "$WORKSPACE/$file" || true
                               done < debian/files
                             fi
+                            # Cleanup temporary build directories
+                            rm -rf "/tmp/debhelper-build-''' + uniqueBuildId + '''" || true
+                            rm -rf "/tmp/build-''' + uniqueBuildId + '''" || true
                         '''
                     }
                 }

--- a/debian/Jenkinsfile.release
+++ b/debian/Jenkinsfile.release
@@ -1,6 +1,6 @@
 #!groovy
 
-String[] distributions = ['debian:bookworm', 'debian:trixie', 'debian:forky', 'ubuntu:jammy', 'ubuntu:noble']
+String[] distributions = ['debian:bookworm', 'debian:trixie', 'debian:forky', 'ubuntu:jammy', 'ubuntu:noble', 'ubuntu:resolute']
 
 String vendor = 'vitexsoftware'
 String imagePrefix = 'multiflexi-'

--- a/debian/io.github.vitexsoftware.debs2sql.metainfo.xml
+++ b/debian/io.github.vitexsoftware.debs2sql.metainfo.xml
@@ -19,6 +19,7 @@
   <developer id="cz.vitexsoftware">
     <name>VitexSoftware</name>
   </developer>
+  <icon type="stock">debs2sql</icon>
   <provides>
     <binary>debs2sql</binary>
   </provides>

--- a/tests/AppStreamMetainfoTest.php
+++ b/tests/AppStreamMetainfoTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the DEBs-to-SQL package
+ *
+ * https://github.com/VitexSoftware/DEBs-to-SQL
+ *
+ * (c) Vítězslav Dvořák <http://vitexsoftware.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Test;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+
+#[CoversNothing]
+class AppStreamMetainfoTest extends \PHPUnit\Framework\TestCase
+{
+    private string $rootDir;
+
+    protected function setUp(): void
+    {
+        $this->rootDir = \dirname(__DIR__);
+    }
+
+    public function testSvgIconExists(): void
+    {
+        $this->assertFileExists($this->rootDir.'/debs2sql.svg');
+    }
+
+    public function testMetainfoExists(): void
+    {
+        $this->assertFileExists($this->rootDir.'/io.github.vitexsoftware.debs2sql.metainfo.xml');
+    }
+
+    public function testMetainfoHasStockIcon(): void
+    {
+        $xml = simplexml_load_file($this->rootDir.'/io.github.vitexsoftware.debs2sql.metainfo.xml');
+        $this->assertNotFalse($xml);
+        $icons = $xml->xpath('//icon[@type="stock"]');
+        $this->assertNotEmpty($icons, 'metainfo.xml must declare a stock icon');
+        $this->assertSame('debs2sql', (string) $icons[0]);
+    }
+
+    public function testDebianMetainfoHasStockIcon(): void
+    {
+        $xml = simplexml_load_file($this->rootDir.'/debian/io.github.vitexsoftware.debs2sql.metainfo.xml');
+        $this->assertNotFalse($xml);
+        $icons = $xml->xpath('//icon[@type="stock"]');
+        $this->assertNotEmpty($icons, 'debian metainfo.xml must declare a stock icon');
+        $this->assertSame('debs2sql', (string) $icons[0]);
+    }
+
+    public function testIconNameMatchesSvgFilename(): void
+    {
+        $xml = simplexml_load_file($this->rootDir.'/io.github.vitexsoftware.debs2sql.metainfo.xml');
+        $this->assertNotFalse($xml);
+        $icons = $xml->xpath('//icon[@type="stock"]');
+        $iconName = (string) $icons[0];
+        $this->assertFileExists($this->rootDir.'/'.$iconName.'.svg');
+    }
+}


### PR DESCRIPTION
## Summary

- Declare `<icon type="stock">debs2sql</icon>` in both `io.github.vitexsoftware.debs2sql.metainfo.xml` and `debian/io.github.vitexsoftware.debs2sql.metainfo.xml`
- Add `tests/AppStreamMetainfoTest.php` with PHPUnit tests verifying the SVG exists, both metainfo files declare the stock icon, and the icon name matches the SVG filename
- Update README with an AppStream section documenting the installed paths
- Sync Jenkinsfiles: add `ubuntu:resolute`, parallel-build isolation via unique `DH_INTERNAL_BUILDDIR`/`TMPDIR`, `sudo chown` before checkout, and graceful `installOrder` handling

## Test plan

- [ ] `php vendor/phpunit/phpunit/phpunit tests/AppStreamMetainfoTest.php` passes all 5 assertions
- [ ] `appstreamcli validate io.github.vitexsoftware.debs2sql.metainfo.xml` reports no errors
- [ ] Built `.deb` installs icon at `/usr/share/icons/hicolor/scalable/apps/debs2sql.svg`
- [ ] Jenkins build succeeds for all distributions including `ubuntu:resolute`

🤖 Generated with [Claude Code](https://claude.com/claude-code)